### PR TITLE
pin binutils to 2.40.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version="11.2.0" %}
 {% set libgfortran_soname="5" %}
-{% set binutils_version="2.38.0" %}
+{% set binutils_version="2.40.0" %}
 {% set glibc_version="2.17" %}  # [not aarch64]
 {% set glibc_version="2.26" %}  # [aarch64]
 
@@ -12,7 +12,7 @@ source:
   path: .
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not linux]
 
 requirements:


### PR DESCRIPTION
### Explanation of changes:

- bump build number
- set binutils to 2.40

Necessary because packages such as cmdstan have a run dependency on the compiler and end up pulling old 2.38 version of binutils.

Triggered by work on https://github.com/AnacondaRecipes/anaconda-feedstock/pull/29