### PR TITLE
gcc_activation 11.2.0 

### DIFF
--- a/recipe/activate-binutils.sh
+++ b/recipe/activate-binutils.sh
@@ -62,8 +62,8 @@ function _tc_activation() {
       esac
       if [ "${pass}" = "apply" ]; then
         thing=$(echo ${thing} | tr 'a-z+-.' 'A-ZX__')
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/activate-g++.sh
+++ b/recipe/activate-g++.sh
@@ -62,8 +62,8 @@ function _tc_activation() {
       esac
       if [ "${pass}" = "apply" ]; then
         thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/activate-gcc.sh
+++ b/recipe/activate-gcc.sh
@@ -62,8 +62,8 @@ function _tc_activation() {
           ;;
       esac
       if [ "${pass}" = "apply" ]; then
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/activate-gfortran.sh
+++ b/recipe/activate-gfortran.sh
@@ -62,8 +62,8 @@ function _tc_activation() {
       esac
       if [ "${pass}" = "apply" ]; then
         thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/deactivate-binutils.sh
+++ b/recipe/deactivate-binutils.sh
@@ -62,8 +62,8 @@ function _tc_activation() {
       esac
       if [ "${pass}" = "apply" ]; then
         thing=$(echo ${thing} | tr 'a-z+-.' 'A-ZX__')
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/deactivate-g++.sh
+++ b/recipe/deactivate-g++.sh
@@ -62,8 +62,8 @@ function _tc_activation() {
       esac
       if [ "${pass}" = "apply" ]; then
         thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/deactivate-gcc.sh
+++ b/recipe/deactivate-gcc.sh
@@ -62,8 +62,8 @@ function _tc_activation() {
           ;;
       esac
       if [ "${pass}" = "apply" ]; then
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/deactivate-gfortran.sh
+++ b/recipe/deactivate-gfortran.sh
@@ -62,8 +62,8 @@ function _tc_activation() {
       esac
       if [ "${pass}" = "apply" ]; then
         thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -109,6 +109,8 @@ outputs:
         - cmake >=3.11
         - make
         - sysroot_{{ target_platform }} {{ glibc_version }}
+        # ${PREFIX}/lib/libquadmath.so: undefined reference to `__signgam@GLIBC_2.23'
+        - libgcc-ng {{ version }}
       commands:
         - ${FC} --version
         - pushd tests/fortomp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   path: .
 
 build:
-  number: 2
+  number: 3
   skip: True  # [not linux]
 
 requirements:

--- a/recipe/tests/fortomp/CMakeLists.txt
+++ b/recipe/tests/fortomp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(fortomp
         LANGUAGES Fortran)
 

--- a/recipe/tests/fortomp/CMakeLists.txt
+++ b/recipe/tests/fortomp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(fortomp
         LANGUAGES Fortran)
 


### PR DESCRIPTION
gcc_activation 11.2.0 

**Destination channel:** Defaults

### Links

- [PKG-12890]
- dev_url:        No/tree/
- conda_forge:    None
- pypi:           https://pypi.org/project/gcc_activation/11.2.0
- pypi inspector: https://inspector.pypi.io/project/gcc_activation/11.2.0

### Explanation of changes:

- the same "unset variables" defensive changes we've seen before in the activation scripts but here for an old GCC
- the fortran test is more interesting:
  - `linux-aarch64` wants `cmake >=3.5` but `linux-64` wants `cmake >=3.10`
  - `linux-64` also has a problem binding to a newer symbol so I've fixed the `libgcc-ng` version to 11
    - not sure that's the best but it makes the fortran test happy when we just want to get the fixed activation scripts out

```
conda create -n foo -y gdb gcc_linux-<arch>=11
```

will fail before but succeed after these additions (with `-c local` if testing locally)

[PKG-12890]: https://anaconda.atlassian.net/browse/PKG-12890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ